### PR TITLE
Black is zero

### DIFF
--- a/src/TiffLibrary/ImageEncoder/PhotometricEncoder/BlackIsZeroEncoder.cs
+++ b/src/TiffLibrary/ImageEncoder/PhotometricEncoder/BlackIsZeroEncoder.cs
@@ -4,23 +4,27 @@ using TiffLibrary.PixelFormats;
 
 namespace TiffLibrary.ImageEncoder.PhotometricEncoder
 {
-    internal class BlackIsZero8Encoder<TPixel> : ITiffImageEncoderMiddleware<TPixel> where TPixel : unmanaged
+    internal class BlackIsZeroEncoder<TPixel> : ITiffImageEncoderMiddleware<TPixel> where TPixel : unmanaged
     {
         public async ValueTask InvokeAsync(TiffImageEncoderContext<TPixel> context, ITiffImageEncoderPipelineNode<TPixel> next)
         {
+            bool is16Bit = typeof(TPixel) == typeof(TiffGray16);
+            int bytesPerSample = (is16Bit ? 2 : 1);
+            ushort bitsPerSample = (ushort) (is16Bit ? 16 : 8);
+
             MemoryPool<byte> memoryPool = context.MemoryPool ?? MemoryPool<byte>.Shared;
             TiffSize imageSize = context.ImageSize;
-            int arraySize = imageSize.Width * imageSize.Height;
+            int arraySize = imageSize.Width * imageSize.Height * bytesPerSample;
             using (IMemoryOwner<byte> pixelData = memoryPool.Rent(arraySize))
             {
-                using (var writer = new TiffMemoryPixelBufferWriter<TiffGray8>(memoryPool, pixelData.Memory, imageSize.Width, imageSize.Height))
+                using (var writer = new TiffMemoryPixelBufferWriter<TPixel>(memoryPool, pixelData.Memory, imageSize.Width, imageSize.Height))
                 using (TiffPixelBufferWriter<TPixel> convertedWriter = context.ConvertWriter(writer.AsPixelBufferWriter()))
                 {
                     await context.GetReader().ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
                 }
 
                 context.PhotometricInterpretation = TiffPhotometricInterpretation.BlackIsZero;
-                context.BitsPerSample = TiffValueCollection.Single<ushort>(8);
+                context.BitsPerSample = TiffValueCollection.Single<ushort>(bitsPerSample);
                 context.UncompressedData = pixelData.Memory.Slice(0, arraySize);
 
                 await next.RunAsync(context).ConfigureAwait(false);

--- a/src/TiffLibrary/ImageEncoder/TiffImageEncoderBuilder.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffImageEncoderBuilder.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using TiffLibrary.Compression;
 using TiffLibrary.ImageEncoder;
 using TiffLibrary.ImageEncoder.PhotometricEncoder;
+using TiffLibrary.PixelFormats;
 
 namespace TiffLibrary
 {
@@ -101,7 +102,7 @@ namespace TiffLibrary
                     pipelineBuilder.Add(new WhiteIsZero8Encoder<TPixel>());
                     break;
                 case TiffPhotometricInterpretation.BlackIsZero:
-                    pipelineBuilder.Add(new BlackIsZero8Encoder<TPixel>());
+                    pipelineBuilder.Add(new BlackIsZeroEncoder<TPixel>());
                     break;
                 case TiffPhotometricInterpretation.RGB:
                     if (EnableTransparencyForRgb)

--- a/tests/TiffLibrary.Tests/Roundtrip/ParallelEncodeTests.cs
+++ b/tests/TiffLibrary.Tests/Roundtrip/ParallelEncodeTests.cs
@@ -10,65 +10,81 @@ namespace TiffLibrary.Tests.Roundtrip
     public class ParallelEncodeTests
     {
         [Theory]
-        [InlineData(true, 0, false)]
-        [InlineData(false, 0, false)]
-        [InlineData(true, 1, false)]
-        [InlineData(false, 1, false)]
-        [InlineData(true, 2, false)]
-        [InlineData(false, 2, false)]
-        [InlineData(true, 4, false)]
-        [InlineData(false, 4, false)]
-        [InlineData(true, 16, false)]
-        [InlineData(false, 16, false)]
-        [InlineData(true, 16, true)]
-        [InlineData(false, 16, true)]
-        public async Task TestRoundtrip(bool isTile, int maxDegreeOfParallelism, bool isYCbCr)
+        [InlineData(true, 0, false, false)]
+        [InlineData(false, 0, false, false)]
+        [InlineData(true, 1, false, false)]
+        [InlineData(false, 1, false, false)]
+        [InlineData(true, 2, false, false)]
+        [InlineData(false, 2, false, false)]
+        [InlineData(true, 4, false, false)]
+        [InlineData(false, 4, false, false)]
+        [InlineData(true, 16, false, false)]
+        [InlineData(false, 16, false, false)]
+        [InlineData(true, 16, true, false)]
+        [InlineData(false, 16, true, false)]
+        [InlineData(true, 0, false, true)]
+        [InlineData(false, 0, false, true)]
+        [InlineData(true, 16, false, true)]
+        [InlineData(false, 16, false, true)]
+        public async Task TestRoundtrip(bool isTile, int maxDegreeOfParallelism, bool isYCbCr, bool is16Bit)
         {
-            TiffGray8[] refImage = new TiffGray8[4096 * 4096];
-            TiffGray8[] testImage = new TiffGray8[4096 * 4096];
-
-            var rand = new Random(42);
-            rand.NextBytes(MemoryMarshal.AsBytes(refImage.AsSpan()));
-
-            var builder = new TiffImageEncoderBuilder();
-            if (isYCbCr)
-            {
-                builder.PhotometricInterpretation = TiffPhotometricInterpretation.YCbCr;
-                builder.HorizontalChromaSubSampling = 2;
-                builder.VerticalChromaSubSampling = 2;
-            }
+            if (is16Bit)
+                await TestRoundTripGeneric<TiffGray16>();
             else
+                await TestRoundTripGeneric<TiffGray8>();
+            return;
+            
+
+            async Task TestRoundTripGeneric<TPixel>() where TPixel : unmanaged, IEquatable<TPixel>
             {
-                builder.PhotometricInterpretation = TiffPhotometricInterpretation.BlackIsZero;
-                builder.Predictor = TiffPredictor.HorizontalDifferencing;
+                int dimension = 4096;
+                TPixel[] refImage = new TPixel[dimension * dimension];
+                TPixel[] testImage = new TPixel[dimension * dimension];
+
+                var rand = new Random(42);
+                rand.NextBytes(MemoryMarshal.AsBytes(refImage.AsSpan()));
+
+                var builder = new TiffImageEncoderBuilder();
+                if (isYCbCr)
+                {
+                    builder.PhotometricInterpretation = TiffPhotometricInterpretation.YCbCr;
+                    builder.HorizontalChromaSubSampling = 2;
+                    builder.VerticalChromaSubSampling = 2;
+                }
+                else
+                {
+                    builder.PhotometricInterpretation = TiffPhotometricInterpretation.BlackIsZero;
+                    builder.Predictor = TiffPredictor.HorizontalDifferencing;
+                }
+
+                builder.Compression = TiffCompression.Lzw;
+                builder.IsTiled = isTile;
+                builder.RowsPerStrip = 64;
+                builder.TileSize = new TiffSize(64, 64);
+                builder.MaxDegreeOfParallelism = maxDegreeOfParallelism;
+
+                var ms = new MemoryStream();
+                await GenerateImageAsync(ms, builder, TiffPixelBuffer.WrapReadOnly(refImage, dimension, dimension));
+
+                ms.Seek(0, SeekOrigin.Begin);
+
+                await using TiffFileReader tiff = await TiffFileReader.OpenAsync(ms, leaveOpen: true);
+                TiffImageDecoder decoder = await tiff.CreateImageDecoderAsync();
+                await decoder.DecodeAsync(TiffPixelBuffer.Wrap(testImage, dimension, dimension));
+
+                Assert.True(refImage.AsSpan().SequenceEqual(testImage.AsSpan()));
             }
-
-            builder.Compression = TiffCompression.Lzw;
-            builder.IsTiled = isTile;
-            builder.RowsPerStrip = 64;
-            builder.TileSize = new TiffSize(64, 64);
-            builder.MaxDegreeOfParallelism = maxDegreeOfParallelism;
-
-            var ms = new MemoryStream();
-            await GenerateImageAsync(ms, builder, TiffPixelBuffer.WrapReadOnly(refImage, 4096, 4096));
-
-            ms.Seek(0, SeekOrigin.Begin);
-
-            await using TiffFileReader tiff = await TiffFileReader.OpenAsync(ms, leaveOpen: true);
-            TiffImageDecoder decoder = await tiff.CreateImageDecoderAsync();
-            await decoder.DecodeAsync(TiffPixelBuffer.Wrap(testImage, 4096, 4096));
-
-            Assert.True(refImage.AsSpan().SequenceEqual(testImage.AsSpan()));
         }
 
-        private static async Task GenerateImageAsync(Stream stream, TiffImageEncoderBuilder builder, TiffPixelBuffer<TiffGray8> image)
+        private static async Task GenerateImageAsync<TPixel>(Stream stream, TiffImageEncoderBuilder builder, TiffPixelBuffer<TPixel> image)
+            where TPixel : unmanaged
         {
             using (TiffFileWriter writer = await TiffFileWriter.OpenAsync(stream, true))
             {
                 TiffStreamOffset ifdOffset;
                 using (TiffImageFileDirectoryWriter ifdWriter = writer.CreateImageFileDirectory())
                 {
-                    TiffImageEncoder<TiffGray8> encoder = builder.Build<TiffGray8>();
+                    TiffImageEncoder<TPixel> encoder = builder.Build<TPixel>();
 
                     await encoder.EncodeAsync(ifdWriter, image);
 


### PR DESCRIPTION
Fixes a problem where 16 bit gray images are not saved correctly; only 8 bit was supported.
Changed BlackIsZero8Encoder to BlackIsZeroEncoder and infer BytePerSample and BitsPerSample from the type.
Also add some unit tests that failed previously.