### PR TITLE
Add the possibility to inject a ITiffPixelBufferReader to optimize large tile based tiffs

### DIFF
--- a/src/TiffLibrary/ImageEncoder/PhotometricEncoder/BlackIsZero8Encoder.cs
+++ b/src/TiffLibrary/ImageEncoder/PhotometricEncoder/BlackIsZero8Encoder.cs
@@ -16,7 +16,17 @@ namespace TiffLibrary.ImageEncoder.PhotometricEncoder
                 using (var writer = new TiffMemoryPixelBufferWriter<TiffGray8>(memoryPool, pixelData.Memory, imageSize.Width, imageSize.Height))
                 using (TiffPixelBufferWriter<TPixel> convertedWriter = context.ConvertWriter(writer.AsPixelBufferWriter()))
                 {
-                    await context.GetReader().ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    if (context.GetReader() is TiffPixelBufferReader<TPixel>)
+                    {
+                        var reader = (TiffPixelBufferReader<TPixel>) context.GetReader();
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+
+                    }
+                    else
+                    {
+                        var reader = new TiffPixelBufferReader<TPixel>(context.GetReader());
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 context.PhotometricInterpretation = TiffPhotometricInterpretation.BlackIsZero;

--- a/src/TiffLibrary/ImageEncoder/PhotometricEncoder/Cmyk32Encoder.cs
+++ b/src/TiffLibrary/ImageEncoder/PhotometricEncoder/Cmyk32Encoder.cs
@@ -18,7 +18,17 @@ namespace TiffLibrary.ImageEncoder.PhotometricEncoder
                 using (var writer = new TiffMemoryPixelBufferWriter<TiffCmyk32>(memoryPool, pixelData.Memory, imageSize.Width, imageSize.Height))
                 using (TiffPixelBufferWriter<TPixel> convertedWriter = context.ConvertWriter(writer.AsPixelBufferWriter()))
                 {
-                    await context.GetReader().ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    if (context.GetReader() is TiffPixelBufferReader<TPixel>)
+                    {
+                        var reader = (TiffPixelBufferReader<TPixel>) context.GetReader();
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+
+                    }
+                    else
+                    {
+                        var reader = new TiffPixelBufferReader<TPixel>(context.GetReader());
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 context.PhotometricInterpretation = TiffPhotometricInterpretation.Seperated;

--- a/src/TiffLibrary/ImageEncoder/PhotometricEncoder/Rgb24Encoder.cs
+++ b/src/TiffLibrary/ImageEncoder/PhotometricEncoder/Rgb24Encoder.cs
@@ -18,7 +18,17 @@ namespace TiffLibrary.ImageEncoder.PhotometricEncoder
                 using (var writer = new TiffMemoryPixelBufferWriter<TiffRgb24>(memoryPool, pixelData.Memory, imageSize.Width, imageSize.Height))
                 using (TiffPixelBufferWriter<TPixel> convertedWriter = context.ConvertWriter(writer.AsPixelBufferWriter()))
                 {
-                    await context.GetReader().ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    if (context.GetReader() is TiffPixelBufferReader<TPixel>)
+                    {
+                        var reader = (TiffPixelBufferReader<TPixel>) context.GetReader();
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+
+                    }
+                    else
+                    {
+                        var reader = new TiffPixelBufferReader<TPixel>(context.GetReader());
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 context.PhotometricInterpretation = TiffPhotometricInterpretation.RGB;

--- a/src/TiffLibrary/ImageEncoder/PhotometricEncoder/Rgba32Encoder.cs
+++ b/src/TiffLibrary/ImageEncoder/PhotometricEncoder/Rgba32Encoder.cs
@@ -18,7 +18,17 @@ namespace TiffLibrary.ImageEncoder.PhotometricEncoder
                 using (var writer = new TiffMemoryPixelBufferWriter<TiffRgba32>(memoryPool, pixelData.Memory, imageSize.Width, imageSize.Height))
                 using (TiffPixelBufferWriter<TPixel> convertedWriter = context.ConvertWriter(writer.AsPixelBufferWriter()))
                 {
-                    await context.GetReader().ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    if (context.GetReader() is TiffPixelBufferReader<TPixel>)
+                    {
+                        var reader = (TiffPixelBufferReader<TPixel>) context.GetReader();
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+
+                    }
+                    else
+                    {
+                        var reader = new TiffPixelBufferReader<TPixel>(context.GetReader());
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 context.PhotometricInterpretation = TiffPhotometricInterpretation.RGB;

--- a/src/TiffLibrary/ImageEncoder/PhotometricEncoder/TransparencyMaskEncoder.cs
+++ b/src/TiffLibrary/ImageEncoder/PhotometricEncoder/TransparencyMaskEncoder.cs
@@ -24,7 +24,17 @@ namespace TiffLibrary.ImageEncoder.PhotometricEncoder
                 using (var writer = new TiffMemoryPixelBufferWriter<TiffMask>(memoryPool, pixelDataMemory, imageSize.Width, imageSize.Height))
                 using (TiffPixelBufferWriter<TPixel> convertedWriter = context.ConvertWriter(writer.AsPixelBufferWriter()))
                 {
-                    await context.GetReader().ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    if (context.GetReader() is TiffPixelBufferReader<TPixel>)
+                    {
+                        var reader = (TiffPixelBufferReader<TPixel>) context.GetReader();
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+
+                    }
+                    else
+                    {
+                        var reader = new TiffPixelBufferReader<TPixel>(context.GetReader());
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 int count = PackBytesIntoBits(pixelDataMemory.Span, imageSize, _threshold);

--- a/src/TiffLibrary/ImageEncoder/PhotometricEncoder/WhiteIsZero8Encoder.cs
+++ b/src/TiffLibrary/ImageEncoder/PhotometricEncoder/WhiteIsZero8Encoder.cs
@@ -18,7 +18,17 @@ namespace TiffLibrary.ImageEncoder.PhotometricEncoder
                 using (var gray8Writer = new TiffGray8ToGray8ReversedPixelConverter(writer))
                 using (TiffPixelBufferWriter<TPixel> convertedWriter = context.ConvertWriter(gray8Writer.AsPixelBufferWriter()))
                 {
-                    await context.GetReader().ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    if (context.GetReader() is TiffPixelBufferReader<TPixel>)
+                    {
+                        var reader = (TiffPixelBufferReader<TPixel>) context.GetReader();
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+
+                    }
+                    else
+                    {
+                        var reader = new TiffPixelBufferReader<TPixel>(context.GetReader());
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 context.PhotometricInterpretation = TiffPhotometricInterpretation.WhiteIsZero;

--- a/src/TiffLibrary/ImageEncoder/PhotometricEncoder/YCbCr24Encoder.cs
+++ b/src/TiffLibrary/ImageEncoder/PhotometricEncoder/YCbCr24Encoder.cs
@@ -22,7 +22,17 @@ namespace TiffLibrary.ImageEncoder.PhotometricEncoder
                 using (var writer = new TiffMemoryPixelBufferWriter<TiffRgb24>(memoryPool, pixelDataMemory, imageSize.Width, imageSize.Height))
                 using (TiffPixelBufferWriter<TPixel> convertedWriter = context.ConvertWriter(writer.AsPixelBufferWriter()))
                 {
-                    await context.GetReader().ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    if (context.GetReader() is TiffPixelBufferReader<TPixel>)
+                    {
+                        var reader = (TiffPixelBufferReader<TPixel>) context.GetReader();
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+
+                    }
+                    else
+                    {
+                        var reader = new TiffPixelBufferReader<TPixel>(context.GetReader());
+                        await reader.ReadAsync(convertedWriter, context.CancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 TiffYCbCrConverter8.CreateDefault().ConvertFromRgb24(MemoryMarshal.Cast<byte, TiffRgb24>(pixelDataMemory.Span), pixelDataMemory.Span, imageSize.Width * imageSize.Height);

--- a/src/TiffLibrary/ImageEncoder/TiffCroppedImageEncoderContext.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffCroppedImageEncoderContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using TiffLibrary.PixelBuffer;
 
 namespace TiffLibrary.ImageEncoder
 {
@@ -33,8 +34,14 @@ namespace TiffLibrary.ImageEncoder
             ImageSize = size;
         }
 
-        public override TiffPixelBufferReader<TPixel> GetReader()
+        public override ITiffPixelBufferReader<TPixel> GetReader()
         {
+            if (InnerContext.GetReader() is TiffOptimizedPartialPixelBufferReaderAdapter<TPixel>)
+            {
+                var reader = (TiffOptimizedPartialPixelBufferReaderAdapter<TPixel>)InnerContext.GetReader();
+                reader.CacheCroppedRegion(ImageOffset, ImageSize);
+                return reader;
+            }
             return InnerContext.GetReader().Crop(ImageOffset, ImageSize);
         }
     }

--- a/src/TiffLibrary/ImageEncoder/TiffDefaultImageEncoderContext.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffDefaultImageEncoderContext.cs
@@ -67,7 +67,7 @@ namespace TiffLibrary.ImageEncoder
         /// <summary>
         /// Gets or sets the reader to read pixels from.
         /// </summary>
-        public ITiffPixelBufferReader<TPixel> PixelBufferReader { get; set; }
+        public ITiffPixelBufferReader<TPixel>? PixelBufferReader { get; set; }
 
         /// <summary>
         /// A <see cref="ITiffPixelConverterFactory"/> implementation to create converters for <see cref="ITiffPixelBufferWriter{TPixel}"/>.
@@ -80,7 +80,7 @@ namespace TiffLibrary.ImageEncoder
         /// <returns>The reader to read pixels from.</returns>
         public override ITiffPixelBufferReader<TPixel> GetReader()
         {
-            return PixelBufferReader;
+            return PixelBufferReader ?? new TiffEmptyPixelBufferReader<TPixel>();
         }
 
         /// <summary>

--- a/src/TiffLibrary/ImageEncoder/TiffDefaultImageEncoderContext.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffDefaultImageEncoderContext.cs
@@ -67,7 +67,7 @@ namespace TiffLibrary.ImageEncoder
         /// <summary>
         /// Gets or sets the reader to read pixels from.
         /// </summary>
-        public TiffPixelBufferReader<TPixel> PixelBufferReader { get; set; }
+        public ITiffPixelBufferReader<TPixel> PixelBufferReader { get; set; }
 
         /// <summary>
         /// A <see cref="ITiffPixelConverterFactory"/> implementation to create converters for <see cref="ITiffPixelBufferWriter{TPixel}"/>.
@@ -78,7 +78,7 @@ namespace TiffLibrary.ImageEncoder
         /// Gets the reader to read pixels from.
         /// </summary>
         /// <returns>The reader to read pixels from.</returns>
-        public override TiffPixelBufferReader<TPixel> GetReader()
+        public override ITiffPixelBufferReader<TPixel> GetReader()
         {
             return PixelBufferReader;
         }

--- a/src/TiffLibrary/ImageEncoder/TiffDelegatingImageEncoderContext.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffDelegatingImageEncoderContext.cs
@@ -32,7 +32,7 @@ namespace TiffLibrary.ImageEncoder
 
         public override TiffStreamRegion OutputRegion { get => _innerContext.OutputRegion; set => _innerContext.OutputRegion = value; }
 
-        public override TiffPixelBufferReader<TPixel> GetReader()
+        public override ITiffPixelBufferReader<TPixel> GetReader()
             => _innerContext.GetReader();
 
         public override TiffPixelBufferWriter<TPixel> ConvertWriter<TBuffer>(TiffPixelBufferWriter<TBuffer> writer)

--- a/src/TiffLibrary/ImageEncoder/TiffImageEncoderBuilder.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffImageEncoderBuilder.cs
@@ -90,7 +90,7 @@ namespace TiffLibrary
         /// </summary>
         /// <typeparam name="TPixel">The pixel type of the input image.</typeparam>
         /// <returns>The <see cref="TiffImageEncoder{TPixel}"/> instance.</returns>
-        public TiffImageEncoder<TPixel> Build<TPixel>() where TPixel : unmanaged
+        public TiffImageEncoderPipelineAdapter<TPixel> Build<TPixel>() where TPixel : unmanaged
         {
             var pipelineBuilder = new TiffImageEncoderPipelineBuilder<TPixel>();
 

--- a/src/TiffLibrary/ImageEncoder/TiffImageEncoderContext.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffImageEncoderContext.cs
@@ -60,7 +60,7 @@ namespace TiffLibrary.ImageEncoder
         /// Gets the reader to read pixels from.
         /// </summary>
         /// <returns>The reader to read pixels from.</returns>
-        public abstract TiffPixelBufferReader<TPixel> GetReader();
+        public abstract ITiffPixelBufferReader<TPixel> GetReader();
 
         /// <summary>
         /// Converts pixel buffer writer of any pixel format <typeparamref name="TBuffer"/> into <see cref="TiffPixelBufferWriter{TPixel}"/>.

--- a/src/TiffLibrary/ImageEncoder/TiffImageEncoderPipelineAdapter.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffImageEncoderPipelineAdapter.cs
@@ -40,9 +40,7 @@ namespace TiffLibrary.ImageEncoder
             {
                 ThrowHelper.ThrowInvalidOperationException("Image encoder is not configured.");
             }
-
-            TiffPixelBufferReader<TPixel> structReader = reader.AsPixelBufferReader();
-            size = new TiffSize(Math.Max(0, Math.Min(structReader.Width - offset.X, size.Width)), Math.Max(0, Math.Min(structReader.Height - offset.Y, size.Height)));
+            size = new TiffSize(Math.Max(0, Math.Min(reader.Width - offset.X, size.Width)), Math.Max(0, Math.Min(reader.Height - offset.Y, size.Height)));
             if (size.IsAreaEmpty)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(nameof(size), "The image size is zero.");
@@ -55,7 +53,7 @@ namespace TiffLibrary.ImageEncoder
                 FileWriter = writer,
                 ImageSize = size,
                 PixelConverterFactory = TiffDefaultPixelConverterFactory.Instance,
-                PixelBufferReader = structReader
+                PixelBufferReader = reader
             };
 
             await _imageEncoder.RunAsync(context).ConfigureAwait(false);
@@ -74,8 +72,7 @@ namespace TiffLibrary.ImageEncoder
                 ThrowHelper.ThrowInvalidOperationException("IFD encoder is not configured.");
             }
 
-            TiffPixelBufferReader<TPixel> structReader = reader.AsPixelBufferReader();
-            size = new TiffSize(Math.Max(0, Math.Min(structReader.Width - offset.X, structReader.Width)), Math.Max(0, Math.Min(structReader.Height - offset.Y, structReader.Height)));
+            size = new TiffSize(Math.Max(0, Math.Min(reader.Width - offset.X, reader.Width)), Math.Max(0, Math.Min(reader.Height - offset.Y, reader.Height)));
             if (size.IsAreaEmpty)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(nameof(size), "The image size is zero.");
@@ -89,7 +86,7 @@ namespace TiffLibrary.ImageEncoder
                 IfdWriter = writer,
                 ImageSize = size,
                 PixelConverterFactory = TiffDefaultPixelConverterFactory.Instance,
-                PixelBufferReader = structReader
+                PixelBufferReader = reader
             };
 
             await _ifdEncoder.RunAsync(context).ConfigureAwait(false);

--- a/src/TiffLibrary/ImageEncoder/TiffImagePaddingMiddleware.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffImagePaddingMiddleware.cs
@@ -59,19 +59,19 @@ namespace TiffLibrary.ImageEncoder
 
             public override TiffSize ImageSize { get => _size; set => ThrowHelper.ThrowNotSupportedException(); }
 
-            public override TiffPixelBufferReader<TPixel> GetReader()
+            public override ITiffPixelBufferReader<TPixel> GetReader()
             {
-                return new PaddedPixelBufferReader(base.GetReader(), _size).AsPixelBufferReader();
+                return new PaddedPixelBufferReader(base.GetReader(), _size);
             }
 
         }
 
         internal class PaddedPixelBufferReader : ITiffPixelBufferReader<TPixel>
         {
-            private readonly TiffPixelBufferReader<TPixel> _reader;
+            private readonly ITiffPixelBufferReader<TPixel> _reader;
             private readonly TiffSize _size;
 
-            public PaddedPixelBufferReader(TiffPixelBufferReader<TPixel> reader, TiffSize size)
+            public PaddedPixelBufferReader(ITiffPixelBufferReader<TPixel> reader, TiffSize size)
             {
                 _reader = reader;
                 _size = size;

--- a/src/TiffLibrary/ImageEncoder/TiffOrientatedImageEncoderContext.cs
+++ b/src/TiffLibrary/ImageEncoder/TiffOrientatedImageEncoderContext.cs
@@ -78,9 +78,9 @@ namespace TiffLibrary.ImageEncoder
             }
         }
 
-        public override TiffPixelBufferReader<TPixel> GetReader()
+        public override ITiffPixelBufferReader<TPixel> GetReader()
         {
-            TiffPixelBufferReader<TPixel> reader = InnerContext.GetReader();
+            ITiffPixelBufferReader<TPixel> reader = InnerContext.GetReader();
             if (_isFlipOrOrientation)
             {
                 return new TiffOrientedPixelBufferReader<TPixel>(reader, _flipLeftRigt, _flipTopBottom).AsPixelBufferReader();

--- a/src/TiffLibrary/PixelBuffer/TiffFlippedPixelBufferReader.cs
+++ b/src/TiffLibrary/PixelBuffer/TiffFlippedPixelBufferReader.cs
@@ -5,11 +5,11 @@ namespace TiffLibrary.PixelBuffer
 {
     internal sealed class TiffFlippedPixelBufferReader<TPixel> : ITiffPixelBufferReader<TPixel> where TPixel : unmanaged
     {
-        private readonly TiffPixelBufferReader<TPixel> _reader;
+        private readonly ITiffPixelBufferReader<TPixel> _reader;
         private readonly bool _flipLeftRight;
         private readonly bool _flipTopBottom;
 
-        public TiffFlippedPixelBufferReader(TiffPixelBufferReader<TPixel> reader, bool flipLeftRight, bool flipTopBottom)
+        public TiffFlippedPixelBufferReader(ITiffPixelBufferReader<TPixel> reader, bool flipLeftRight, bool flipTopBottom)
         {
             _reader = reader;
             _flipLeftRight = flipLeftRight;

--- a/src/TiffLibrary/PixelBuffer/TiffOptimizedPartialPixelBufferReaderAdapter.cs
+++ b/src/TiffLibrary/PixelBuffer/TiffOptimizedPartialPixelBufferReaderAdapter.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Drawing;
+using System.Threading;
+using System.Threading.Tasks;
+using TiffLibrary.Utils;
+
+namespace TiffLibrary.PixelBuffer
+{
+    /// <summary>
+    /// Uses <see cref="ITiffPixelBuffer{TPixel}"/> as the underlying storage. Provides <see cref="ITiffPixelBufferReader{TPixel}"/> API to read pixels from <see cref="ITiffPixelBuffer{TPixel}"/>.
+    /// </summary>
+    /// <typeparam name="TPixel"></typeparam>
+    public class TiffOptimizedPartialPixelBufferReaderAdapter<TPixel> : ITiffPixelBufferReader<TPixel> where TPixel : unmanaged
+    {
+        private readonly IPartialBufferProvider<TPixel> _partialBufferProvider;
+        private Rectangle _croppedRegion;
+
+        /// <summary>
+        /// Initialize the object to wrap <paramref name="partialBufferProvider"/>.
+        /// </summary>
+        /// <param name="partialBufferProvider">The chunked pixel buffer provider for partial access.</param>
+        public TiffOptimizedPartialPixelBufferReaderAdapter(IPartialBufferProvider<TPixel> partialBufferProvider)
+        {
+            _partialBufferProvider = partialBufferProvider;
+        }
+
+        /// <inheritdoc />
+        public int Width => _partialBufferProvider.ImageSize.Width;
+
+        /// <inheritdoc />
+        public int Height => _partialBufferProvider.ImageSize.Height;
+
+        /// <inheritdoc />
+        public ValueTask ReadAsync(TiffPoint offset, TiffPixelBufferWriter<TPixel> destination, CancellationToken cancellationToken)
+        {
+            if (offset.X >= (uint)_partialBufferProvider.ImageSize.Width || offset.Y >= (uint)_partialBufferProvider.ImageSize.Height)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(offset));
+            }
+
+            int width = Math.Min(_croppedRegion.Width - offset.X, destination.Width);
+            int height = Math.Min(_croppedRegion.Height - offset.Y, destination.Height);
+
+            var memoryBuffer = _partialBufferProvider.GetMemoryBuffer(_croppedRegion);
+            var result = memoryBuffer.GetReadOnlySpan();
+
+            int bufferWidth = _croppedRegion.Width;
+
+            for (int row = 0; row < height; row++)
+            {
+                ReadOnlySpan<TPixel> sourceSpan = result.Slice(bufferWidth * (offset.Y + row) + offset.X, width);
+                using TiffPixelSpanHandle<TPixel> destinationHandle = destination.GetRowSpan(row);
+                sourceSpan.CopyTo(destinationHandle.GetSpan());
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Save the cropped region input to be processed by the reader later.
+        /// </summary>
+        /// <param name="imageOffset"></param>
+        /// <param name="imageSize"></param>
+        public void CacheCroppedRegion(TiffPoint imageOffset, TiffSize imageSize)
+        {
+            _croppedRegion = new Rectangle() {X = imageOffset.X, Y = imageOffset.Y, Width = imageSize.Width, Height = imageSize.Height};
+        }
+    }
+}

--- a/src/TiffLibrary/PixelBuffer/TiffOrientedPixelBufferReader.cs
+++ b/src/TiffLibrary/PixelBuffer/TiffOrientedPixelBufferReader.cs
@@ -5,11 +5,11 @@ namespace TiffLibrary.PixelBuffer
 {
     internal sealed class TiffOrientedPixelBufferReader<TPixel> : ITiffPixelBufferReader<TPixel> where TPixel : unmanaged
     {
-        private readonly TiffPixelBufferReader<TPixel> _reader;
+        private readonly ITiffPixelBufferReader<TPixel> _reader;
         private readonly bool _flipLeftRight;
         private readonly bool _flipTopBottom;
 
-        public TiffOrientedPixelBufferReader(TiffPixelBufferReader<TPixel> reader, bool flipLeftRight, bool flipTopBottom)
+        public TiffOrientedPixelBufferReader(ITiffPixelBufferReader<TPixel> reader, bool flipLeftRight, bool flipTopBottom)
         {
             _reader = reader;
             _flipLeftRight = flipLeftRight;

--- a/src/TiffLibrary/Utils/IPartialBufferProvider.cs
+++ b/src/TiffLibrary/Utils/IPartialBufferProvider.cs
@@ -1,0 +1,20 @@
+﻿using System.Drawing;
+
+namespace TiffLibrary.Utils;
+
+/// <summary>
+///
+/// </summary>
+/// <typeparam name="TPixel"></typeparam>
+public interface IPartialBufferProvider<TPixel> where TPixel : unmanaged
+{
+    /// <summary>
+    /// The size of the image that is being processed. If it is multi-resolution tiff. Please extend the class to provide dynamic values here.
+    /// </summary>
+    TiffSize ImageSize { get; }
+
+    /// <summary>
+    /// The return the memory buffer. Given the region on the image. If it is multi-resolution tiff. Please optimize extend the class to manage different levels.
+    /// </summary>
+    public TiffMemoryPixelBuffer<TPixel> GetMemoryBuffer(Rectangle imageRegion);
+}

--- a/tests/TiffLibrary.Tests/ImageEncoderMiddlewares/ApplyChromaSubsamplingTests.cs
+++ b/tests/TiffLibrary.Tests/ImageEncoderMiddlewares/ApplyChromaSubsamplingTests.cs
@@ -197,7 +197,7 @@ namespace TiffLibrary.Tests.ImageEncoderMiddlewares
                 throw new NotSupportedException();
             }
 
-            public override TiffPixelBufferReader<TPixel> GetReader()
+            public override ITiffPixelBufferReader<TPixel> GetReader()
             {
                 throw new NotSupportedException();
             }

--- a/tests/TiffLibrary.Tests/OptimizedPartialBufferProvider/OptimizedPartialBufferProvider.cs
+++ b/tests/TiffLibrary.Tests/OptimizedPartialBufferProvider/OptimizedPartialBufferProvider.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Drawing;
+using TiffLibrary.PixelFormats;
+using TiffLibrary.Utils;
+
+namespace TiffLibrary.Tests.OptimizedPartialBufferProvider
+{
+    public class OptimizedPartialBufferProvider : IPartialBufferProvider<TiffGray8>
+    {
+        private readonly TiffSize _baseLevelSize;
+
+        private int _layer;
+        private TiffSize _levelSize;
+
+        public OptimizedPartialBufferProvider(TiffSize baseLevelSize)
+        {
+            _baseLevelSize = baseLevelSize;
+            SetLayer(0);
+        }
+
+        public TiffSize ImageSize => _levelSize;
+
+        public void SetLayer(int layer)
+        {
+            _layer = layer;
+
+            int inverseScale = (int) Math.Pow(2, layer);
+
+            int thisLevelWidth = (int) Math.Ceiling(_baseLevelSize.Width / (double) inverseScale);
+            int thisLevelHeight = (int) Math.Ceiling(_baseLevelSize.Height / (double) inverseScale);
+
+            _levelSize = new TiffSize(thisLevelWidth, thisLevelHeight);
+        }
+
+        /// <summary>
+        /// The return the memory buffer. Given the region on the image. If it is multi-resolution tiff. Please optimize extend the class to manage different levels.
+        /// </summary>
+        public TiffMemoryPixelBuffer<TiffGray8> GetMemoryBuffer(Rectangle imageRegion)
+        {
+            var tmp = new TiffGray8[imageRegion.Width * imageRegion.Height];
+            return new TiffMemoryPixelBuffer<TiffGray8>(tmp, imageRegion.Width, imageRegion.Height, false);
+        }
+
+    }
+}

--- a/tests/TiffLibrary.Tests/OptimizedPartialBufferProvider/OptimizedPartialBufferProviderTests.cs
+++ b/tests/TiffLibrary.Tests/OptimizedPartialBufferProvider/OptimizedPartialBufferProviderTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp;
+using TiffLibrary.PixelBuffer;
+using TiffLibrary.PixelFormats;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TiffLibrary.Tests.OptimizedPartialBufferProvider
+{
+    public class OptimizedPartialBufferProviderTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public OptimizedPartialBufferProviderTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async Task WritePyramidTiledTiffUsingOptimizedPartialBufferProvider()
+        {
+            string tmpFilePath = Path.Combine(Path.GetTempPath(), "tmp.tiff");
+
+            try
+            {
+                await using var writer = await TiffFileWriter.OpenAsync(tmpFilePath, useBigTiff: true);
+
+                var baseImageSize = new Size(5316, 5316);
+                int tileSize = 256;
+
+                // Build The image encoder.
+                var encoderBuilder = new TiffImageEncoderBuilder
+                {
+                    PhotometricInterpretation = TiffPhotometricInterpretation.BlackIsZero,
+                    IsTiled = true,
+                    TileSize = new TiffSize(tileSize, tileSize),
+                    Compression = TiffCompression.NoCompression
+                };
+
+                // We just build the pyramid to the last until one tile
+                var numberOfPyramidLevelsForHeight = (int)Math.Ceiling(Math.Log2(baseImageSize.Height / (double)tileSize));
+                var numberOfPyramidLevelsForWidth = (int)Math.Ceiling(Math.Log2(baseImageSize.Width / (double)tileSize));
+                int numberOfPyramidLevels = Math.Min(numberOfPyramidLevelsForHeight, numberOfPyramidLevelsForWidth);
+
+                TiffStreamOffset lastIfdOffset = -1;
+
+                var encoder = encoderBuilder.Build<TiffGray8>();
+                var bufferProvider = new OptimizedPartialBufferProvider(new TiffSize(baseImageSize.Width, baseImageSize.Height));
+
+                List<ulong> subIfdStreamOffsets = await WriteSubIfds(bufferProvider, writer, encoder,
+                    numberOfPyramidLevels).ConfigureAwait(false);
+                if (lastIfdOffset == -1)
+                {
+                    lastIfdOffset = await WriteMainIfd(bufferProvider, writer, encoder, subIfdStreamOffsets, null).ConfigureAwait(false);
+                    // Set this IFD to be the first IFD.
+                    writer.SetFirstImageFileDirectoryOffset(lastIfdOffset);
+                }
+                else
+                {
+                    lastIfdOffset = await WriteMainIfd(bufferProvider, writer, encoder, subIfdStreamOffsets, lastIfdOffset).ConfigureAwait(false);
+                }
+
+                // Flush TIFF file header.
+                await writer.FlushAsync().ConfigureAwait(false);
+
+            }
+            catch (Exception e)
+            {
+                _testOutputHelper.WriteLine(e.ToString());
+                throw;
+            }
+            finally
+            {
+                if (File.Exists(tmpFilePath))
+                {
+                    File.Delete(tmpFilePath);
+                }
+            }
+        }
+
+        private async Task<TiffStreamOffset> WriteMainIfd(OptimizedPartialBufferProvider optimizedBufferProvider, TiffFileWriter writer,
+            TiffImageEncoder<TiffGray8> encoder, List<ulong> subIfdOffsets, TiffStreamOffset? lastMainIfdOffset)
+        {
+            using TiffImageFileDirectoryWriter ifdWriter = writer.CreateImageFileDirectory();
+
+            optimizedBufferProvider.SetLayer(0);
+            var optimizedTiledPixelReader = new TiffOptimizedPartialPixelBufferReaderAdapter<TiffGray8>(optimizedBufferProvider);
+            await encoder.EncodeAsync(ifdWriter, optimizedTiledPixelReader).ConfigureAwait(false);
+
+            await ifdWriter.WriteTagAsync(TiffTag.SamplesPerPixel, TiffValueCollection.Single((short)1)).ConfigureAwait(false);
+            await ifdWriter.WriteTagAsync(TiffTag.PlanarConfiguration, TiffValueCollection.Single((short)1)).ConfigureAwait(false);
+            await ifdWriter.WriteTagAsync(TiffTag.SampleFormat, TiffValueCollection.Single((short)1)).ConfigureAwait(false);
+
+            await ifdWriter.WriteTagAsync(TiffTag.SubIFDs, TiffValueCollection.UnsafeWrap(subIfdOffsets.ToArray())).ConfigureAwait(false);
+
+            TiffStreamOffset nextIfdOffset;
+            if (lastMainIfdOffset != null)
+            {
+                nextIfdOffset = await ifdWriter.FlushAsync(lastMainIfdOffset.Value).ConfigureAwait(false);
+            }
+            else
+            {
+                nextIfdOffset = await ifdWriter.FlushAsync().ConfigureAwait(false);
+            }
+
+            return nextIfdOffset;
+        }
+
+        private async Task<List<ulong>> WriteSubIfds(OptimizedPartialBufferProvider optimizedBufferProvider, TiffFileWriter writer,
+            TiffImageEncoder<TiffGray8> encoder, int numberOfPyramidLevels)
+        {
+            var subIfdOffsets = new List<ulong>();
+
+            for (int level = numberOfPyramidLevels; level >= 1; level--)
+            {
+                using TiffImageFileDirectoryWriter ifdWriter = writer.CreateImageFileDirectory();
+
+                optimizedBufferProvider.SetLayer(level);
+
+                var optimizedTiledPixelReader = new TiffOptimizedPartialPixelBufferReaderAdapter<TiffGray8>(optimizedBufferProvider);
+                await encoder.EncodeAsync(ifdWriter, optimizedTiledPixelReader).ConfigureAwait(false);
+
+                await ifdWriter.WriteTagAsync(TiffTag.SamplesPerPixel, TiffValueCollection.Single((short)1)).ConfigureAwait(false);
+                await ifdWriter.WriteTagAsync(TiffTag.PlanarConfiguration, TiffValueCollection.Single((short)1)).ConfigureAwait(false);
+                await ifdWriter.WriteTagAsync(TiffTag.SampleFormat, TiffValueCollection.Single((short)1)).ConfigureAwait(false);
+
+                await ifdWriter.WriteTagAsync(TiffTag.NewSubfileType, TiffValueCollection.Single((short)1)).ConfigureAwait(false);
+                TiffStreamOffset ifdOffset = await ifdWriter.FlushAsync().ConfigureAwait(false);
+                subIfdOffsets.Add((ulong) ifdOffset.ToInt64());
+            }
+
+            return subIfdOffsets;
+        }
+    }
+}

--- a/tests/TiffLibrary.Tests/PhotometricInterpretations/YCbCr888Tests.cs
+++ b/tests/TiffLibrary.Tests/PhotometricInterpretations/YCbCr888Tests.cs
@@ -63,7 +63,7 @@ namespace TiffLibrary.Tests.PhotometricInterpretations
             byte[] ycbcrReference = new byte[count * 3];
             converter.ConvertFromRgb24(reference.AsSpan(offset, count), ycbcrReference, count);
 
-            using TiffFileReader reader = await TiffFileReader.OpenAsync(fileContent);
+            await using TiffFileReader reader = await TiffFileReader.OpenAsync(fileContent);
             TiffImageDecoder decoder = await reader.CreateImageDecoderAsync();
 
             TiffRgb24[] pixels = new TiffRgb24[count];


### PR DESCRIPTION
I encountered a problem encoding a very large tiled image. First there is a performance issue forcing the usage of MemoryBuffer. Second, the MemoryBuffer has max array size that is System.Int32.MaxValue. 

In this commit, I added the following: 
- Keep ITiffPixelBufferReader as abstract as possible until necessary for a cast.
- Allow injection of IPartialBufferProvider.
- Provide test / example how to use IPartialBufferProvider to optimize the buffer preparation speed. 
- All tests run green.